### PR TITLE
add sidebar table of content for pages and index

### DIFF
--- a/lib/rdoc/generator/snapper.rb
+++ b/lib/rdoc/generator/snapper.rb
@@ -182,6 +182,10 @@ module RDoc
 
       # Generate an index page which lists all the classes which are documented
       def generate_index
+        if @options.main_page && main_page = @files.find { |f| f.full_name == @options.main_page }
+          current = main_page
+          file = main_page
+        end
         template_file = @template_dir + "index.rhtml"
         out_file = @base_dir + @options.op_dir + "index.html"
         rel_prefix = @outputdir.relative_path_from(out_file.dirname)

--- a/lib/rdoc/generator/template/snapper/_sidebar_table_of_contents.rhtml
+++ b/lib/rdoc/generator/template/snapper/_sidebar_table_of_contents.rhtml
@@ -2,68 +2,109 @@
   <nav class="right-nav">
     <span id="right-side-bar-title" class="right-side-bar-title">On this page</span>
         <ul>
-          <li id="right-side-bar-<%=klass.aref.to_s.downcase.gsub('::','-')%>" class="right-side-bar-<%= klass.type %>">
-            <%= klass.type %> <%= klass.full_name %>
-          
-            <ul>
-              <%- klass.each_section do |section, constants, attributes| -%>
-                <%- unless constants.empty? then -%>
-                  <li>
-                  <details open>
-                  <summary id="right-side-bar-section-constants" class="right-side-bar-section">Constants</summary>
-                    <ul>
-                      <%- constants.each do |const| -%>
-                        <li id="right-nav-<%= const.name %>" class="right-side-bar-element">
-                          <a href="#<%= const.name %>">
-                          <%= const.name %>
-                          </a>
-                        </li>
-                      <%- end -%>
-                    </ul>
-                  </details>
-                  </li>
-                <%- end -%>
+          <%- if defined?(klass) -%>
+            <li id="right-side-bar-<%=klass.aref.to_s.downcase.gsub('::','-')%>" class="right-side-bar-<%= klass.type %>">
+              <a href="#" ><%= klass.type %> <%= klass.full_name %></a>
+            
+              <ul>
+                <%- klass.each_section do |section, constants, attributes| -%>
+                  <%- unless constants.empty? then -%>
+                    <li>
+                    <details open>
+                    <summary id="right-side-bar-section-constants" class="right-side-bar-section">Constants</summary>
+                      <ul>
+                        <%- constants.each do |const| -%>
+                          <li id="right-nav-<%= const.name %>" class="right-side-bar-element">
+                            <a href="#<%= const.name %>">
+                            <%= const.name %>
+                            </a>
+                          </li>
+                        <%- end -%>
+                      </ul>
+                    </details>
+                    </li>
+                  <%- end -%>
 
-                <%- unless attributes.empty? then -%>
-                  <li>
-                  <details open>
-                  <summary id="right-side-bar-section-attributes" class="right-side-bar-section">Attributes</summary>
-                    <ul>
-                      <%- attributes.each do |attrib| -%>
-                        <li id="right-nav-<%= attrib.name %>" class="right-side-bar-element">
-                          <a href="#<%= attrib.aref %>">
-                            <%= attrib.name %>
-                            </a>
-                        </li>
-                      <%- end -%>
-                    </ul>
-                  </details>
-                  </li>
-                <%- end -%>
-                <%- klass.methods_by_type(section).each do |type, visibilities|
-                  next if visibilities.empty?
-                  visibilities.each do |visibility, methods|
-                    next if methods.empty? %>
-                  
-                  <li>
-                  <details open>
-                  <summary id="right-side-bar-section-<%= visibility.to_s.downcase %>-<%= type.capitalize.to_s.downcase %>-methods" class="right-side-bar-section"><%= visibility.to_s.capitalize %> <%= type.capitalize %> Methods</summary>
-                    <ul>
-                      <%- methods.each do |method| -%>
-                        <li id="right-nav-<%= method.name %>" class="right-side-bar-element">
-                          <a href="#<%= method.aref %>">
-                            <%= method.name %>
-                            </a>
-                        </li>
-                      <%- end -%>
-                    </ul>
-                  </details>
-                  </li>
+                  <%- unless attributes.empty? then -%>
+                    <li>
+                    <details open>
+                    <summary id="right-side-bar-section-attributes" class="right-side-bar-section">Attributes</summary>
+                      <ul>
+                        <%- attributes.each do |attrib| -%>
+                          <li id="right-nav-<%= attrib.name %>" class="right-side-bar-element">
+                            <a href="#<%= attrib.aref %>">
+                              <%= attrib.name %>
+                              </a>
+                          </li>
+                        <%- end -%>
+                      </ul>
+                    </details>
+                    </li>
+                  <%- end -%>
+                  <%- klass.methods_by_type(section).each do |type, visibilities|
+                    next if visibilities.empty?
+                    visibilities.each do |visibility, methods|
+                      next if methods.empty? %>
+                    
+                    <li>
+                    <details open>
+                    <summary id="right-side-bar-section-<%= visibility.to_s.downcase %>-<%= type.capitalize.to_s.downcase %>-methods" class="right-side-bar-section"><%= visibility.to_s.capitalize %> <%= type.capitalize %> Methods</summary>
+                      <ul>
+                        <%- methods.each do |method| -%>
+                          <li id="right-nav-<%= method.name %>" class="right-side-bar-element">
+                            <a href="#<%= method.aref %>">
+                              <%= method.name %>
+                              </a>
+                          </li>
+                        <%- end -%>
+                      </ul>
+                    </details>
+                    </li>
+                  <%- end -%>
                 <%- end -%>
               <%- end -%>
-            <%- end -%>
-          </li>
-        </ul>
-      </li>
+            </li>
+          </ul>
+        </li>
+      <%- elsif defined?(file) -%>
+        <li> <a href=#><%= file.full_name.gsub('.rdoc','')%></a></li>
+        <%- comment = if current.respond_to? :comment_location then
+               current.comment_location
+             else
+               current.comment
+             end
+           table = current.parse(comment).table_of_contents.dup
+           if table.length > 1 then %>
+            <div class="nav-section">
+              <%- display_link = proc do |heading| -%>
+                <a href="#<%= heading.label current %>"><%= heading.plain_html %></a>
+              <%- end -%>
+              <%- list_siblings = proc do -%>
+                <%- level = table.first&.level -%>
+                <%- while table.first && table.first.level >= level -%>
+                  <%- heading = table.shift -%>
+                  <%- if table.first.nil? || table.first.level <= heading.level -%>
+                    <li><% display_link.call heading -%>
+                  <%- else -%>
+                    <li>
+                      <details open>
+                        <summary><%- display_link.call heading -%></summary>
+                        <ul class="link-list" role="directory">
+                          <% list_siblings.call %>
+                        </ul>
+                      </details>
+                    </li>
+                  <%- end -%>
+                <%- end -%>
+              <%- end -%>
+
+              <ul class="link-list" role="directory">
+                <% list_siblings.call %>
+              </ul>
+            </div>
+          <%- end -%>
+          <%- else -%>
+            <li><a href= "#" ><%= @title %></a></li>
+        <%- end -%>
   </nav>
 </div>

--- a/lib/rdoc/generator/template/snapper/css/snapper.css
+++ b/lib/rdoc/generator/template/snapper/css/snapper.css
@@ -317,7 +317,7 @@ details>summary::-webkit-details-marker {
 
 .right-section {
   min-width: 300px;
-  height: 100vh;
+  height: 90vh;
   padding: 1em;
   padding-left: 2em;
   overflow-y: scroll;
@@ -363,7 +363,6 @@ details>summary::-webkit-details-marker {
 .right-side-bar-section {
     text-transform: capitalize;
 } 
-=======
 /* Code blocks syntax highlighting */
 .ruby-constant {
     color: #4b82e9;

--- a/lib/rdoc/generator/template/snapper/index.rhtml
+++ b/lib/rdoc/generator/template/snapper/index.rhtml
@@ -8,6 +8,7 @@
       <p>This is the API documentation for <%= h @title %>.
     <%- end -%>
   </main>
+  <%= render "_sidebar_table_of_contents.rhtml" %>
 </div>
 
 <%= render "_search_modal.rhtml" %>

--- a/lib/rdoc/generator/template/snapper/page.rhtml
+++ b/lib/rdoc/generator/template/snapper/page.rhtml
@@ -2,6 +2,7 @@
   <%= render "_sidebar.rhtml" %>
 
   <main><%= file.description %></main>
+  <%= render "_sidebar_table_of_contents.rhtml" %>
 </div>
 
 <%= render "_search_modal.rhtml" %>


### PR DESCRIPTION
Modifies "table of content" sidebar to work for pages and index page

![image](https://github.com/Shopify/rdoc/assets/60617358/30d241c3-61ae-45bc-89fd-7b436b8e1192)
