### PR TITLE
Improve chevron alignment

### DIFF
--- a/lib/rdoc/generator/template/snapper/css/snapper.css
+++ b/lib/rdoc/generator/template/snapper/css/snapper.css
@@ -188,6 +188,14 @@ details[open]>summary:after {
     bottom: 8px;
 }
 
+.link-list summary::after {
+    bottom: 10px;
+}
+
+.link-list details[open]>summary:after {
+    bottom: 12px;
+}
+
 details>summary {
     list-style: none;
 }


### PR DESCRIPTION
They were slightly misaligned with the table of content titles.