### PR TITLE
Use a pseudoelement for "</>" in the title

### DIFF
--- a/lib/rdoc/generator/template/snapper/_sidebar.rhtml
+++ b/lib/rdoc/generator/template/snapper/_sidebar.rhtml
@@ -1,5 +1,5 @@
 <nav id="nav">
-  <h3 class="title">&lt;/&gt; <%= @title %></h3>
+  <h3 class="title"><%= @title %></h3>
 
   <input id="side-search" type="text" placeholder="Search docs"></input>
 

--- a/lib/rdoc/generator/template/snapper/css/snapper.css
+++ b/lib/rdoc/generator/template/snapper/css/snapper.css
@@ -169,6 +169,14 @@ code {
     white-space: nowrap;
 }
 
+.title:before {
+  content: "</>";
+  padding: 0 0.5em;
+  font-size: 0.8em;
+  font-weight: normal;
+  color: rgb(175, 190, 195);
+}
+
 .expandable-index-entry:hover>details>summary,
 .expandable-index-entry details[open]>summary {
     background-color: #F6F6F9;


### PR DESCRIPTION
This is a tiny change to use a pseudoelement for the decoration on the site title. It looks like this:

![Screenshot 2023-07-28 at 4 35 17 PM](https://github.com/Shopify/rdoc/assets/6955296/75891cb2-3b19-44e0-bc38-ebe845813152)
