### PR TITLE
Create our own search index

### DIFF
--- a/lib/rdoc/generator/template/snapper/js/snapper.js
+++ b/lib/rdoc/generator/template/snapper/js/snapper.js
@@ -6,7 +6,6 @@ let sideSearchInput;
 let searchInput;
 let searchResults;
 let mainContainer;
-let searchIndex = search_data.index;
 
 function hideSearchModal() {
   searchModal.style.display = "none";
@@ -19,13 +18,9 @@ function showSearchModal() {
 
   if (searchResults.innerHTML === "") {
     // Populate the search modal with the first 10 items to start
-    const initialEntries = searchIndex.info.slice(0, 10).map((entry) => {
-      return {
-        title: entry[0],
-        namespace: entry[1],
-        path: entry[2],
-        snippet: entry[4],
-      };
+    const keys = Object.keys(searchIndex).slice(0, 10);
+    const initialEntries = keys.map((key) => {
+      return searchIndex[key];
     });
     searchResults.innerHTML = htmlForResults(initialEntries);
   }
@@ -96,21 +91,7 @@ function setupSearch() {
       }
 
       const regex = new RegExp(event.target.value, "i");
-      const results = [];
-
-      searchIndex.longSearchIndex.forEach((entry, index) => {
-        if (regex.test(entry)) {
-          const info = searchIndex.info[index];
-
-          // The data indexed by JsonIndex is in an array format
-          results.push({
-            title: info[0],
-            namespace: info[1],
-            path: info[2],
-            snippet: info[4],
-          });
-        }
-      });
+      const results = Object.keys(searchIndex).filter((key) => regex.test(key)).map((key) => searchIndex[key]);
 
       if (results.length === 0) {
         searchResults.innerHTML = "<li><p>No results found</p></li>";


### PR DESCRIPTION
The JSON index generates the search information in an odd format. Instead of needing to re-process it on the JS side, let's create our own search index in the format that is most convenient.