### PR TITLE
Remove CSP from the Snapper template

### DIFF
--- a/lib/rdoc/generator/template/snapper/_head.rhtml
+++ b/lib/rdoc/generator/template/snapper/_head.rhtml
@@ -1,7 +1,6 @@
 <head>
   <meta charset="<%= @options.charset %>">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline'; img-src https:"/>
 
   <title><%= h @title %></title>
 


### PR DESCRIPTION
Since the Snapper template doesn't include any 3rd party content and is completely static, there's no need to include a Content Security Policy

More importantly, the current CSP blocks the use of local assets, which would be a breaking change for anyone switching to this template as darkfish currently doesn't include a CSP.