### PR TITLE
Prevented overflow of text outside the codeblock

### DIFF
--- a/lib/rdoc/generator/template/snapper/css/snapper.css
+++ b/lib/rdoc/generator/template/snapper/css/snapper.css
@@ -111,6 +111,7 @@ code {
 pre {
     padding: calc(var(--space) / 2);
     border: 1px solid #DFDFE8;
+    overflow-x: auto;
 }
 
 code {


### PR DESCRIPTION
The [Ruby-LSP documentation](https://shopify.github.io/ruby-lsp) uses the `create_snapper_generator` branch of [Shopify/rdoc](https://github.com/Shopify/rdoc) to generate the documentation (Refer to [Shopify/ruby-lsp#Gemfile](https://github.com/Shopify/ruby-lsp/blob/722e4a8c8853d042253069a2002fd010a77a8a1c/Gemfile#L15)).

This PR fixes the overflow of text content within code blocks by adding a `overflow-x: auto` property.

**URL**: https://shopify.github.io/ruby-lsp

### Screenshots

**Before**

<img width="1440" alt="Screenshot 2024-04-30 at 10 17 39 PM" src="https://github.com/Shopify/rdoc/assets/35297280/9e1a7dca-d58e-4026-b33a-2551c00dd75e">

**After**

<img width="1440" alt="Screenshot 2024-04-30 at 10 17 33 PM" src="https://github.com/Shopify/rdoc/assets/35297280/dd2fcadc-15d3-4635-8258-e0493c00eaa9">
